### PR TITLE
Fix for link devices being deleted (such as ppp interfaces) when using monitor()

### DIFF
--- a/lib/link/utils.js
+++ b/lib/link/utils.js
@@ -79,12 +79,18 @@ exports.parse_links = function (raw_data) {
       var link_line_1 = output[line];
       var link_fields_1 = link_line_1.trim().split(/\s/g);
 
+      var del = link_fields_1[0] === 'Deleted';
+      if(del) {
+        link_fields_1.shift();
+      }
+      
       var link_line_2 = output[line + 1];
       var link_fields_2 = link_line_2.trim().split(/\s/g);
 
       var name = link_fields_1[1].split(':')[0];
       var link = {
         index: link_fields_1[0].split(':')[0], // Don't needed since the array is ordered anyway but just in case.
+				deleted: del,
         name : name,
         flags: link_fields_1[2].slice(1, -1).split(','), // First remove the <,> chars.
 


### PR DESCRIPTION
Hi,

I am using your module (thanks for sharing) for a project that monitors link level devices, which includes a ppp interface.  When the ppp interface goes down, `ip monitor` reports it as `Deleted` in the output, but isn't parsed correctly by node-iproute.

This PR fixes it.

Here is the output from ip monitor all

```
[LINK]27: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
[LINK]Deleted 27: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
[LINK]28: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
[LINK]Deleted 28: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
[LINK]29: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
[LINK]Deleted 29: ppp0: <POINTOPOINT,MULTICAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
    link/ppp 
```

The output from node-iproute was:

```
{"object":"link","data":[{"index":"28","name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
{"object":"link","data":[{"1500":"qdisc","index":"Deleted","name":"28","flags":["pp0"],"type":"ppp","<POINTOPOINT,MULTICAST,NOARP>":"mtu","noop":"state","DOWN":"group"}]}
{"object":"link","data":[{"index":"29","name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
{"object":"link","data":[{"1500":"qdisc","index":"Deleted","name":"29","flags":["pp0"],"type":"ppp","<POINTOPOINT,MULTICAST,NOARP>":"mtu","noop":"state","DOWN":"group"}]}
{"object":"link","data":[{"index":"30","name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
{"object":"link","data":[{"1500":"qdisc","index":"Deleted","name":"30","flags":["pp0"],"type":"ppp","<POINTOPOINT,MULTICAST,NOARP>":"mtu","noop":"state","DOWN":"group"}]}
```
The repeated up and down is the dialer repeatedly attempting to connect via 3G and failing.

With this PR, the output is as follows:

```
link:{"object":"link","data":[{"index":"28","deleted":false,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
link:{"object":"link","data":[{"index":"28","deleted":true,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
link:{"object":"link","data":[{"index":"29","deleted":false,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
link:{"object":"link","data":[{"index":"29","deleted":true,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
link:{"object":"link","data":[{"index":"30","deleted":false,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
link:{"object":"link","data":[{"index":"30","deleted":true,"name":"ppp0","flags":["POINTOPOINT","MULTICAST","NOARP"],"type":"ppp","mtu":"1500","qdisc":"noop","state":"DOWN","group":"default"}]}
```

Are you happy to merge this with your repo?

Cheers,
Damien.