### PR TITLE
Adding options parameter for pass sudo to ip_forward

### DIFF
--- a/docs/README-utils.md
+++ b/docs/README-utils.md
@@ -12,13 +12,15 @@ General helpful utils to provide extra handy functionality not present in `iprou
 
 Path to IP forwarding kernel setting file path.
 
-### ip_utils.ip_forward.v{4,6}.enable(cb)
-### ip_utils.ip_forward.v{4,6}.disable(cb)
-### ip_utils.ip_forward.v{4,6}.status(cb)
+### ip_utils.ip_forward.v{4,6}.enable(options, cb)
+For now, the options parameter only accepts {sudo: true or false}.
+Don't worry if you did write your code in a previos version of this module and did informed just cb function, without options. The code will run without problems. 
+### ip_utils.ip_forward.v{4,6}.disable(options, cb)
+### ip_utils.ip_forward.v{4,6}.status(options, cb)
 
-### ip_utils.ip_forward.enable(cb)
-### ip_utils.ip_forward.disable(cb)
-### ip_utils.ip_forward.status(cb)
+### ip_utils.ip_forward.enable(options, cb)
+### ip_utils.ip_forward.disable(options, cb)
+### ip_utils.ip_forward.status(options, cb)
 
 ## ip_utils.routing_tables
 

--- a/lib/utils/ip_forward.js
+++ b/lib/utils/ip_forward.js
@@ -16,11 +16,8 @@ function sysctl(options, cb) {
    * Build cmd to execute.
    */
   var cmd = ['sysctl'];
-  /*
-   * If not root user - append sudo.
-   */
-  if(process.getuid() > 0){
-    var cmd = ['sudo sysctl'];
+  if(options.sudo){
+    cmd = ['sudo sysctl'];
   }
   var args = [];
 
@@ -65,22 +62,41 @@ function sysctl(options, cb) {
 var v4_path = 'net.ipv4.ip_forward';
 var v4 = {
   path   : v4_path,
-  enable : function (cb) {
+  enable : function (options, cb) {
+    /*
+     * For compatibility reasons. If options is a function, the developer did developed his code with an older version.
+     * copy options to cb and change options to null.
+     */
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'enable',
-      path  : v4_path
+      path  : v4_path,
+      sudo: options.sudo || false
     }, cb);
   },
-  disable: function (cb) {
+  disable: function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'disable',
-      path  : v4_path
+      path  : v4_path,
+      sudo: options.sudo || false
     }, cb);
   },
-  status : function (cb) {
+  status : function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'status',
-      path  : v4_path
+      path  : v4_path,
+      sudo: options.sudo || false
     }, cb);
   }
 };
@@ -88,22 +104,37 @@ var v4 = {
 var v6_path = 'net.ipv6.conf.all.forwarding';
 var v6 = {
   path   : v6_path,
-  enable : function (cb) {
+  enable : function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'enable',
-      path  : v6_path
+      path  : v6_path,
+      sudo: options.sudo || false
     }, cb);
   },
-  disable: function (cb) {
+  disable: function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'disable',
-      path  : v6_path
+      path  : v6_path,
+      sudo: options.sudo || false
     }, cb);
   },
-  status : function (cb) {
+  status : function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     sysctl({
       action: 'status',
-      path  : v6_path
+      path  : v6_path,
+      sudo: options.sudo || false
     }, cb);
   }
 };
@@ -111,10 +142,14 @@ var v6 = {
 module.exports = {
   v4     : v4,
   v6     : v6,
-  enable : function (cb) {
+  enable : function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     async.parallel([
       function (callback_parallel) {
-        v4.enable(function (error) {
+        v4.enable(options, function (error) {
           if (error) {
             callback_parallel(error);
           }
@@ -124,7 +159,7 @@ module.exports = {
         });
       },
       function (callback_parallel) {
-        v6.enable(function (error) {
+        v6.enable(options, function (error) {
           if (error) {
             callback_parallel(error);
           }
@@ -143,10 +178,14 @@ module.exports = {
         }
       });
   },
-  disable: function (cb) {
+  disable: function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     async.parallel([
       function (callback_parallel) {
-        v4.disable(function (error) {
+        v4.disable(options, function (error) {
           if (error) {
             callback_parallel(error);
           }
@@ -156,7 +195,7 @@ module.exports = {
         });
       },
       function (callback_parallel) {
-        v6.disable(function (error) {
+        v6.disable(options, function (error) {
           if (error) {
             callback_parallel(error);
           }
@@ -175,10 +214,14 @@ module.exports = {
         }
       });
   },
-  status : function (cb) {
+  status : function (options, cb) {
+    if(typeof(options) == 'function' && !cb){
+        cb = options;
+        options = {};
+    }
     async.parallel([
       function (callback_parallel) {
-        v4.status(function (error, status) {
+        v4.status(options, function (error, status) {
           if (error) {
             callback_parallel(error);
           }
@@ -188,7 +231,7 @@ module.exports = {
         });
       },
       function (callback_parallel) {
-        v6.status(function (error, status) {
+        v6.status(options, function (error, status) {
           if (error) {
             callback_parallel(error);
           }

--- a/lib/utils/ip_forward.js
+++ b/lib/utils/ip_forward.js
@@ -16,6 +16,12 @@ function sysctl(options, cb) {
    * Build cmd to execute.
    */
   var cmd = ['sysctl'];
+  /*
+   * If not root user - append sudo.
+   */
+  if(process.getuid() > 0){
+    var cmd = ['sudo sysctl'];
+  }
   var args = [];
 
   switch (options.action) {
@@ -39,7 +45,10 @@ function sysctl(options, cb) {
    * Execute command.
    */
   exec(cmd.concat(args).join(' '), function (error, stdout, stderror) {
-    if (error) {
+    /*
+    * For some reason, command always contains stderror, but with length 0. A condition do avoid false positive.
+    */
+    if (error || (typeof(stderror) != 'null' && stderror.length > 0)) {
       cb(stderror.replace(/\n/g, '') + '. Executed command line: ' + cmd.concat(args).join(' '));
     }
     else {


### PR DESCRIPTION
Hi. 

I did add a options parameter to ip_forward. This parameter follows the pattern of the other modules of this project and have as objective pass "sudo" option to the commands.

In case of module updating in code writen in a previous version, I added a treatment to execute without options parameter, just with cb function.

Thanks a lot.