### PR TITLE
Add support for "can" type, and "bitrate" property

### DIFF
--- a/__tests__/safe/cmd-generation/fixtures/link-add.ts
+++ b/__tests__/safe/cmd-generation/fixtures/link-add.ts
@@ -829,6 +829,26 @@ export const Tests: TestFixture<LinkAddOptions>[] = [
       OnOffToggle.On
     ],
     expectedCmdToExec: ` ip link add link eth0 name macsec0 type ${ LinkTypes.Macsec } sci 0102030405060708 cipher gcm-aes-128 icvlen 16 encrypt on`
+  },
+  {
+    description:       'with `type can`',
+    options:           {
+      name: 'can0',
+      type: {
+        [LinkTypes.Can]: true,
+      }
+    },
+    expectedCmd:       [
+      '',
+      'ip',
+      'link',
+      'add',
+      'name',
+      'can0',
+      'type',
+      LinkTypes.Can
+    ],
+    expectedCmdToExec: ` ip link add name can0 type ${ LinkTypes.Can }`
   }
 ];
 

--- a/__tests__/safe/cmd-generation/fixtures/link-set.ts
+++ b/__tests__/safe/cmd-generation/fixtures/link-set.ts
@@ -1,6 +1,7 @@
 import { LinkSetOptions } from '../../../../src/commands/link/set.interfaces';
 import { TestFixture } from '../../../../src/common/interfaces/tests';
 import { XdpOptionTypes } from '../../../../src';
+import { LinkTypes } from '../../../../src/commands/link.constants';
 
 export const Tests: TestFixture<LinkSetOptions>[] = [
   {
@@ -88,6 +89,28 @@ export const Tests: TestFixture<LinkSetOptions>[] = [
       '/sys/fs/bpf/foo'
     ],
     expectedCmdToExec: ` ip link set eth0 xdp ${XdpOptionTypes.Pinned} /sys/fs/bpf/foo`
+  },
+  {
+    description: 'with type can and bitrate',
+    options: {
+      dev: 'can0',
+      type: {
+        [LinkTypes.Can]: true,
+      },
+      bitrate: 500000
+    },
+    expectedCmd: [
+      '',
+      'ip',
+      'link',
+      'set',
+      'can0',
+      'type',
+      'can',
+      'bitrate',
+      500000
+    ],
+    expectedCmdToExec: ` ip link set can0 type can bitrate 500000`
   }
 ];
 

--- a/src/commands/link.constants.ts
+++ b/src/commands/link.constants.ts
@@ -21,6 +21,8 @@ export const LinkTypes = {
   Macvtap: 'macvtap',
   /** Virtual Controller Area Network interface. */
   Vcan: 'vcan',
+  /** Controller Area Network interface. */
+  Can: 'can',
   /** Virtual Controller Area Network tunnel interface. */
   Vxcan: 'vxcan',
   /** Virtual ethernet interface. */

--- a/src/commands/link/add.interfaces.ts
+++ b/src/commands/link/add.interfaces.ts
@@ -108,6 +108,7 @@ export interface LinkTypesMappings {
   [LinkTypes.Dummy]: true;
   [LinkTypes.Ifb]: true;
   [LinkTypes.Vcan]: true;
+  [LinkTypes.Can]: true;
   [LinkTypes.Ip6tnl]: true;
   [LinkTypes.Vti]: true;
   [LinkTypes.Nlmon]: true;

--- a/src/commands/link/add.schema.ts
+++ b/src/commands/link/add.schema.ts
@@ -82,6 +82,11 @@ export const typePropertiesSchema: any = {
     enum: [true],
     nullable: true
   },
+  [LinkTypes.Can]: {
+    type: 'boolean',
+    enum: [true],
+    nullable: true
+  },
   [LinkTypes.Ip6tnl]: {
     type: 'boolean',
     enum: [true],

--- a/src/commands/link/set.interfaces.ts
+++ b/src/commands/link/set.interfaces.ts
@@ -75,6 +75,8 @@ export interface LinkSetCommonOptions {
   trailers?: OnOffToggle;
   /** Change the transmit queue length of the device. */
   txqueuelen?: number;
+  /** Change the bitrate of the device. */
+  bitrate?: number;
   /**
    * Change the name of the device.
    * This operation is not recommended if the device is running or has some addresses already configured.

--- a/src/commands/link/set.schema.ts
+++ b/src/commands/link/set.schema.ts
@@ -120,6 +120,11 @@ export const LinkSetSchema: JSONSchemaType<LinkSetOptions> = {
       minimum:  1,
       nullable: true
     },
+    bitrate:          {
+      type:     'integer',
+      minimum:  1,
+      nullable: true
+    },
     name:             {
       type:     'string',
       format:   'mac',


### PR DESCRIPTION
Thanks for the great node module!

I would like to use this on an embedded system to configure the CAN ports on the fly without needing to exec ip commands, but I found that I could not set "can" type devices and "bitrate" was not supported.

A typical command to configure a can port would look something like this:
`sudo ip link set can0 type can bitrate 125000`

I tested my changes locally and it seems to do the trick.

Please let me know if you would like me to spin the version in this PR or if you will do that before publishing?